### PR TITLE
Add sidebar layout and persistent state

### DIFF
--- a/app.js
+++ b/app.js
@@ -216,10 +216,29 @@ let state = {
     currentSection: 'dashboard'
 };
 
+function saveState() {
+    localStorage.setItem('newpayState', JSON.stringify(state));
+}
+
+function loadState() {
+    const saved = localStorage.getItem('newpayState');
+    if (saved) {
+        try {
+            state = JSON.parse(saved);
+        } catch (e) {
+            console.error('Error loading saved state', e);
+        }
+    }
+}
+
 // Inicialización de la aplicación
 document.addEventListener('DOMContentLoaded', function() {
-    // Generar datos iniciales aleatorios
-    generateInitialData();
+    loadState();
+    if (!state.products || state.products.length === 0) {
+        generateInitialData();
+    } else {
+        calculateFinancials();
+    }
     
     // Configurar navegación
     setupNavigation();
@@ -523,6 +542,7 @@ function updateUI() {
     updateBCGSection();
     updateStrategiesSection();
     updatePLSection();
+    saveState();
 }
 
 // Actualizar dashboard

--- a/index.html
+++ b/index.html
@@ -11,21 +11,25 @@
 </head>
 <body>
     <div class='container'>
-        <header>
-            <h1><i class='fas fa-chart-line'></i> Simulador Estratégico NewPay</h1>
+        <aside id='sidebar'>
+            <h1><i class='fas fa-chart-line'></i> NewPay</h1>
             <nav id='main-nav'>
                 <ul>
-                    <li><a href='#dashboard' class='active'><i class='fas fa-tachometer-alt'></i> Dashboard</a></li>
-                    <li><a href='#productos'><i class='fas fa-boxes'></i> Productos</a></li>
                     <li><a href='#clientes'><i class='fas fa-users'></i> Clientes</a></li>
+                    <li><a href='#productos'><i class='fas fa-boxes'></i> Productos</a></li>
+                    <li><a href='#dashboard' class='active'><i class='fas fa-tachometer-alt'></i> Dashboard</a></li>
                     <li><a href='#entorno'><i class='fas fa-globe-americas'></i> Análisis del Entorno</a></li>
                     <li><a href='#competitivo'><i class='fas fa-chess'></i> Análisis Competitivo</a></li>
-                    <li><a href='#bcg'><i class='fas fa-matrix'></i> Matriz BCG</a></li>
+                    <li><a href='#bcg'><i class='fas fa-matrix'></i> Análisis de Crecimiento</a></li>
                     <li><a href='#estrategias'><i class='fas fa-chess-knight'></i> Estrategias</a></li>
                     <li><a href='#pl'><i class='fas fa-file-invoice-dollar'></i> P&L</a></li>
                 </ul>
             </nav>
-        </header>
+        </aside>
+        <div class='content'>
+            <header>
+                <h1>Simulador Estratégico NewPay</h1>
+            </header>
 
         <main>
             <!-- Sección Dashboard -->
@@ -314,9 +318,9 @@
                 </div>
             </section>
 
-            <!-- Sección Matriz BCG -->
+            <!-- Sección Análisis de Crecimiento -->
             <section id='bcg'>
-                <h2><i class='fas fa-matrix'></i> Matriz BCG</h2>
+                <h2><i class='fas fa-matrix'></i> Análisis de Crecimiento</h2>
                 <div class='bcg-container'>
                     <div class='bcg-matrix'>
                         <div class='bcg-quadrant' id='star'>
@@ -408,7 +412,7 @@
                                 <option value=''>-- Seleccione --</option>
                                 <option value='PESTEL'>Del Análisis del Entorno</option>
                                 <option value='Porter'>Del Análisis Competitivo</option>
-                                <option value='Ansoff'>De la Matriz BCG</option>
+                                <option value='Ansoff'>Del Análisis de Crecimiento</option>
                                 <option value='custom'>Personalizada</option>
                             </select>
                         </div>
@@ -509,6 +513,7 @@
         <footer>
             <p>Simulador Estratégico NewPay &copy; 2023</p>
         </footer>
+        </div>
     </div>
 
     <!-- Modal -->

--- a/style.css
+++ b/style.css
@@ -13,8 +13,52 @@ body {
 }
 
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
+    display: flex;
+    min-height: 100vh;
+}
+
+#sidebar {
+    width: 220px;
+    background-color: #2c3e50;
+    color: white;
+    padding: 20px;
+}
+
+#sidebar h1 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 20px;
+    margin-bottom: 20px;
+}
+
+#main-nav ul {
+    list-style: none;
+    padding: 0;
+}
+
+#main-nav ul li {
+    margin-bottom: 10px;
+}
+
+#main-nav ul li a {
+    color: white;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 8px 10px;
+    border-radius: 3px;
+    transition: background-color 0.3s;
+}
+
+#main-nav ul li a:hover,
+#main-nav ul li a.active {
+    background-color: #2980b9;
+}
+
+.content {
+    flex: 1;
     padding: 20px;
 }
 
@@ -33,33 +77,6 @@ header h1 {
     padding: 0 20px;
 }
 
-nav ul {
-    display: flex;
-    list-style: none;
-    padding: 10px 20px;
-    background-color: #34495e;
-    border-radius: 5px;
-    margin-top: 10px;
-}
-
-nav ul li {
-    margin-right: 15px;
-}
-
-nav ul li a {
-    color: white;
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    padding: 5px 10px;
-    border-radius: 3px;
-    transition: background-color 0.3s;
-}
-
-nav ul li a:hover, nav ul li a.active {
-    background-color: #2980b9;
-}
 
 section {
     background-color: white;
@@ -447,8 +464,8 @@ input, select, textarea {
         flex-direction: column;
     }
     
-    nav ul {
-        flex-wrap: wrap;
+    #main-nav ul {
+        flex-direction: column;
     }
 }
 


### PR DESCRIPTION
## Summary
- move navigation to sidebar and reorder menu
- rename BCG section to 'Análisis de Crecimiento'
- adjust styles for vertical sidebar
- persist simulator state in `localStorage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685973a760688330a42b329da9999785